### PR TITLE
IDN inquiry fix

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -22,7 +22,7 @@ from pyqtgraph import GraphicsLayoutWidget, DateAxisItem, AxisItem, ViewBox, Plo
 from pyqtgraph.parametertree import Parameter, ParameterTree, parameterTypes
 
 # current version number displayed in the GUI (Major.Minor.Patch or Breaking.Feature.Fix)
-version_number = "0.9.1"
+version_number = "0.9.2"
 
 # Define instrument types
 CPC = 1


### PR DESCRIPTION
changes to IDN inquiries to improve reliability:
- IDN is checked every time a device is connected/reconnected
- all port descriptions are reset when updating port list (to avoid false serial numbers)
- if port is busy when updating port list, serial number is retrieved from device parameters